### PR TITLE
Fix problems in long_cache_key method

### DIFF
--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -70,7 +70,7 @@ module Spree
       order.shipments.each do |shipment|
         key << shipment.avatax_cache_key
       end
-      order.all_adjustments.non_tax do |adj|
+      order.all_adjustments.non_tax.each do |adj|
         key << adj.avatax_cache_key
       end
       key

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -63,7 +63,7 @@ module Spree
 
     def long_cache_key(order)
       key = order.avatax_cache_key
-      key << order.tax_address.try(:cache_key)
+      key << order.tax_address.try(:cache_key).to_s
       order.line_items.each do |line_item|
         key << line_item.avatax_cache_key
       end


### PR DESCRIPTION
There are 2 problems in this method:
- if the order doesn't have a `ship_address` this will raise an error
- non-tax adjustments are never actually included in the cache key