### PR TITLE
Fix shipment discount bug

### DIFF
--- a/spec/factories/avalara_order_factory.rb
+++ b/spec/factories/avalara_order_factory.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
       line_items_count 1
       line_items_quantity 1
       shipment_cost 5
+      stock_location { build(:stock_location) }
       tax_category Spree::TaxCategory.first
       tax_included false
     end
@@ -35,7 +36,7 @@ FactoryBot.define do
       create_list(:line_item, evaluator.line_items_count, order: order, price: evaluator.line_items_price, tax_category: evaluator.tax_category, quantity: evaluator.line_items_quantity)
       order.line_items.reload
 
-      create(:avalara_shipment, order: order, cost: evaluator.shipment_cost, tax_included: evaluator.tax_included)
+      create(:avalara_shipment, order: order, cost: evaluator.shipment_cost, tax_included: evaluator.tax_included, stock_location: evaluator.stock_location)
       order.shipments.reload
 
       order.updater.update

--- a/spec/models/solidus_avatax_certified/request/get_tax_spec.rb
+++ b/spec/models/solidus_avatax_certified/request/get_tax_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SolidusAvataxCertified::Request::GetTax, :vcr do
         createTransactionModel: {
           code: order.number,
           date: Date.today.to_s,
-          discount: "0.0",
+          discount: 0.0,
           commit: false,
           type: "SalesOrder",
           lines: [
@@ -135,10 +135,10 @@ RSpec.describe SolidusAvataxCertified::Request::GetTax, :vcr do
         expect(Spree::PromotionHandler::Coupon.new(order).apply).to be_successful
       end
 
-      it "sends an invoice discount amount" do
+      it "sends the full item price and an invoice discount" do
         expect(subject).to include(
           createTransactionModel: hash_including(
-            discount: "5.0",
+            discount: 5.0,
             lines: [
               hash_including(
                 amount: 5.0,
@@ -161,12 +161,10 @@ RSpec.describe SolidusAvataxCertified::Request::GetTax, :vcr do
       end
 
 
-      # TODO this test will fail as is because we send shipping discounts in
-      # invoice discount, but then also send the discounted amount for the item.
-      xit "sends the discounted shipment amount" do
+      it "sends the discounted shipment amount" do
         expect(subject).to include(
           createTransactionModel: hash_including(
-            discount: "0.0",
+            discount: 0.0,
             lines: [
               anything,
               hash_including(

--- a/spec/vcr/SolidusAvataxCertified_Request_GetTax/_generate/with_a_line_item_discount/sends_an_invoice_discount_amount.yml
+++ b/spec/vcr/SolidusAvataxCertified_Request_GetTax/_generate/with_a_line_item_discount/sends_an_invoice_discount_amount.yml
@@ -1,0 +1,169 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+    body:
+      encoding: UTF-8
+      string: '{"createTransactionModel":{"code":"R123164970","date":"2018-06-26","discount":"5.0","commit":false,"type":"SalesOrder","lines":[{"number":"1-LI","description":"Product
+        #2 - 5976","taxCode":"PC030000","itemCode":"SKU-2","quantity":1,"amount":5.0,"discounted":true,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
+        Lombard Street","line2":null,"city":"San Francisco","region":"CA","country":"US","postalCode":"94109"},"shipTo":{"line1":"42
+        Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null},{"number":"1-FR","itemCode":"Avalara
+        Ground","quantity":1,"amount":5.0,"description":"Shipping Charge","taxCode":"FR000000","discounted":false,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
+        Lombard Street","line2":null,"city":"San Francisco","region":"CA","country":"US","postalCode":"94109"},"shipTo":{"line1":"42
+        Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null}],"customerCode":1,"companyCode":"001","customerUsageType":null,"exemptionNo":null,"referenceCode":"R123164970","currencyCode":"USD","businessIdentificationNo":null}}'
+    headers:
+      X-Avalara-Uid:
+      - a0o33000004FH8l
+      User-Agent:
+      - Faraday v0.15.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic MTEwMDEyNzQwNjo2MEM4RTU4RkYxMDU1MjBD
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 Jun 2018 22:34:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Location:
+      - "/api/v2/companies/0/transactions/0"
+      Server:
+      - Kestrel
+      Serverduration:
+      - '00:00:00.0993445'
+      Databasecalls:
+      - '0'
+      Databaseduration:
+      - '00:00:00'
+      Serviceduration:
+      - '00:00:00.0955463'
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: '{"id":0,"code":"R123164970","companyId":0,"date":"2018-06-26","paymentDate":"2018-06-26","status":"Temporary","type":"SalesOrder","currencyCode":"USD","customerVendorCode":"1","customerCode":"1","reconciled":false,"referenceCode":"R123164970","totalAmount":10.0,"totalExempt":0.0,"totalDiscount":5.0,"totalTax":0.47,"totalTaxable":5.0,"totalTaxCalculated":0.47,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2018-06-26","exchangeRate":1.0,"modifiedDate":"2018-06-26T22:34:49.8040203Z","modifiedUserId":41103,"taxDate":"2018-06-26T00:00:00","lines":[{"id":0,"transactionId":0,"lineNumber":"1-LI","description":"Product
+        #2 - 5976","discountAmount":5.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"SKU-2","lineAmount":0.0,"quantity":1.0,"reportingDate":"2018-06-26","tax":0.0,"taxableAmount":0.0,"taxCalculated":0.0,"taxCode":"PC030000","taxCodeId":8107,"taxDate":"2018-06-26","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        STATE TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"075","jurisName":"SAN
+        FRANCISCO","stateAssignedNo":"","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0,"rate":0.002500,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        COUNTY TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMAR0","jurisName":"LOS
+        ANGELES COUNTY DISTRICT TAX SP","stateAssignedNo":"594","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.022500,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMTV0","jurisName":"SAN
+        FRANCISCO CO LOCAL TAX SL","stateAssignedNo":"38","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.010000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"","vatNumberTypeId":0},{"id":0,"transactionId":0,"lineNumber":"1-FR","description":"Shipping
+        Charge","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"Avalara
+        Ground","lineAmount":5.0,"quantity":1.0,"reportingDate":"2018-06-26","tax":0.47,"taxableAmount":5.0,"taxCalculated":0.47,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2018-06-26","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.3,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        STATE TAX","taxAuthorityTypeId":45,"taxCalculated":0.3,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"075","jurisName":"SAN
+        FRANCISCO","stateAssignedNo":"","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0,"rate":0.002500,"tax":0.01,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        COUNTY TAX","taxAuthorityTypeId":45,"taxCalculated":0.01,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMAR0","jurisName":"LOS
+        ANGELES COUNTY DISTRICT TAX SP","stateAssignedNo":"594","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.022500,"tax":0.11,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.11,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMTV0","jurisName":"SAN
+        FRANCISCO CO LOCAL TAX SL","stateAssignedNo":"38","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.010000,"tax":0.05,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.05,"rateType":"General","rateTypeCode":"G","isNonPassThru":false}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"","vatNumberTypeId":0}],"addresses":[{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"42
+        Fake Street","line2":"Southeast","line3":"","city":"Los Angeles","region":"CA","postalCode":"90210","country":"US","taxRegionId":2127184,"latitude":"34.086013","longitude":"-118.404905"},{"id":0,"transactionId":0,"boundaryLevel":"Address","line1":"1070
+        Lombard Street","line2":"","line3":"","city":"San Francisco","region":"CA","postalCode":"94109","country":"US","taxRegionId":2128434,"latitude":"37.802069","longitude":"-122.41912"}],"summary":[{"country":"US","region":"CA","jurisType":"State","jurisCode":"06","jurisName":"CALIFORNIA","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Sales","taxName":"CA
+        STATE TAX","rateType":"General","taxable":5.0,"rate":0.060000,"tax":0.3,"taxCalculated":0.3,"nonTaxable":0.0,"exemption":0.0},{"country":"US","region":"CA","jurisType":"County","jurisCode":"075","jurisName":"SAN
+        FRANCISCO","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Sales","taxName":"CA
+        COUNTY TAX","rateType":"General","taxable":5.0,"rate":0.002500,"tax":0.01,"taxCalculated":0.01,"nonTaxable":0.0,"exemption":0.0},{"country":"US","region":"CA","jurisType":"Special","jurisCode":"EMAR0","jurisName":"LOS
+        ANGELES COUNTY DISTRICT TAX SP","taxAuthorityType":45,"stateAssignedNo":"594","taxType":"Sales","taxName":"CA
+        SPECIAL TAX","rateType":"General","taxable":5.0,"rate":0.022500,"tax":0.11,"taxCalculated":0.11,"nonTaxable":0.0,"exemption":0.0},{"country":"US","region":"CA","jurisType":"Special","jurisCode":"EMTV0","jurisName":"SAN
+        FRANCISCO CO LOCAL TAX SL","taxAuthorityType":45,"stateAssignedNo":"38","taxType":"Sales","taxName":"CA
+        SPECIAL TAX","rateType":"General","taxable":5.0,"rate":0.010000,"tax":0.05,"taxCalculated":0.05,"nonTaxable":0.0,"exemption":0.0}]}'
+    http_version: 
+  recorded_at: Tue, 26 Jun 2018 22:34:50 GMT
+- request:
+    method: post
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+    body:
+      encoding: UTF-8
+      string: '{"createTransactionModel":{"code":"R123164970","date":"2018-06-26","discount":"5.0","commit":false,"type":"SalesOrder","lines":[{"number":"1-LI","description":"Product
+        #2 - 5976","taxCode":"PC030000","itemCode":"SKU-2","quantity":1,"amount":5.0,"discounted":true,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
+        Lombard Street","line2":null,"city":"San Francisco","region":"CA","country":"US","postalCode":"94109"},"shipTo":{"line1":"42
+        Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null},{"number":"1-FR","itemCode":"Avalara
+        Ground","quantity":1,"amount":5.0,"description":"Shipping Charge","taxCode":"FR000000","discounted":false,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
+        Lombard Street","line2":null,"city":"San Francisco","region":"CA","country":"US","postalCode":"94109"},"shipTo":{"line1":"42
+        Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null}],"customerCode":1,"companyCode":"001","customerUsageType":null,"exemptionNo":null,"referenceCode":"R123164970","currencyCode":"USD","businessIdentificationNo":null}}'
+    headers:
+      X-Avalara-Uid:
+      - a0o33000004FH8l
+      User-Agent:
+      - Faraday v0.15.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic MTEwMDEyNzQwNjo2MEM4RTU4RkYxMDU1MjBD
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 Jun 2018 22:34:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Location:
+      - "/api/v2/companies/0/transactions/0"
+      Server:
+      - Kestrel
+      Serverduration:
+      - '00:00:00.1014522'
+      Databasecalls:
+      - '0'
+      Databaseduration:
+      - '00:00:00'
+      Serviceduration:
+      - '00:00:00.0973509'
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: '{"id":0,"code":"R123164970","companyId":0,"date":"2018-06-26","paymentDate":"2018-06-26","status":"Temporary","type":"SalesOrder","currencyCode":"USD","customerVendorCode":"1","customerCode":"1","reconciled":false,"referenceCode":"R123164970","totalAmount":10.0,"totalExempt":0.0,"totalDiscount":5.0,"totalTax":0.47,"totalTaxable":5.0,"totalTaxCalculated":0.47,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2018-06-26","exchangeRate":1.0,"modifiedDate":"2018-06-26T22:34:50.25904Z","modifiedUserId":41103,"taxDate":"2018-06-26T00:00:00","lines":[{"id":0,"transactionId":0,"lineNumber":"1-LI","description":"Product
+        #2 - 5976","discountAmount":5.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"SKU-2","lineAmount":0.0,"quantity":1.0,"reportingDate":"2018-06-26","tax":0.0,"taxableAmount":0.0,"taxCalculated":0.0,"taxCode":"PC030000","taxCodeId":8107,"taxDate":"2018-06-26","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        STATE TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"075","jurisName":"SAN
+        FRANCISCO","stateAssignedNo":"","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0,"rate":0.002500,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        COUNTY TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMAR0","jurisName":"LOS
+        ANGELES COUNTY DISTRICT TAX SP","stateAssignedNo":"594","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.022500,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMTV0","jurisName":"SAN
+        FRANCISCO CO LOCAL TAX SL","stateAssignedNo":"38","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.010000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"","vatNumberTypeId":0},{"id":0,"transactionId":0,"lineNumber":"1-FR","description":"Shipping
+        Charge","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"Avalara
+        Ground","lineAmount":5.0,"quantity":1.0,"reportingDate":"2018-06-26","tax":0.47,"taxableAmount":5.0,"taxCalculated":0.47,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2018-06-26","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.3,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        STATE TAX","taxAuthorityTypeId":45,"taxCalculated":0.3,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"075","jurisName":"SAN
+        FRANCISCO","stateAssignedNo":"","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0,"rate":0.002500,"tax":0.01,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        COUNTY TAX","taxAuthorityTypeId":45,"taxCalculated":0.01,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMAR0","jurisName":"LOS
+        ANGELES COUNTY DISTRICT TAX SP","stateAssignedNo":"594","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.022500,"tax":0.11,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.11,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMTV0","jurisName":"SAN
+        FRANCISCO CO LOCAL TAX SL","stateAssignedNo":"38","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.010000,"tax":0.05,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.05,"rateType":"General","rateTypeCode":"G","isNonPassThru":false}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"","vatNumberTypeId":0}],"addresses":[{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"42
+        Fake Street","line2":"Southeast","line3":"","city":"Los Angeles","region":"CA","postalCode":"90210","country":"US","taxRegionId":2127184,"latitude":"34.086013","longitude":"-118.404905"},{"id":0,"transactionId":0,"boundaryLevel":"Address","line1":"1070
+        Lombard Street","line2":"","line3":"","city":"San Francisco","region":"CA","postalCode":"94109","country":"US","taxRegionId":2128434,"latitude":"37.802069","longitude":"-122.41912"}],"summary":[{"country":"US","region":"CA","jurisType":"State","jurisCode":"06","jurisName":"CALIFORNIA","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Sales","taxName":"CA
+        STATE TAX","rateType":"General","taxable":5.0,"rate":0.060000,"tax":0.3,"taxCalculated":0.3,"nonTaxable":0.0,"exemption":0.0},{"country":"US","region":"CA","jurisType":"County","jurisCode":"075","jurisName":"SAN
+        FRANCISCO","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Sales","taxName":"CA
+        COUNTY TAX","rateType":"General","taxable":5.0,"rate":0.002500,"tax":0.01,"taxCalculated":0.01,"nonTaxable":0.0,"exemption":0.0},{"country":"US","region":"CA","jurisType":"Special","jurisCode":"EMAR0","jurisName":"LOS
+        ANGELES COUNTY DISTRICT TAX SP","taxAuthorityType":45,"stateAssignedNo":"594","taxType":"Sales","taxName":"CA
+        SPECIAL TAX","rateType":"General","taxable":5.0,"rate":0.022500,"tax":0.11,"taxCalculated":0.11,"nonTaxable":0.0,"exemption":0.0},{"country":"US","region":"CA","jurisType":"Special","jurisCode":"EMTV0","jurisName":"SAN
+        FRANCISCO CO LOCAL TAX SL","taxAuthorityType":45,"stateAssignedNo":"38","taxType":"Sales","taxName":"CA
+        SPECIAL TAX","rateType":"General","taxable":5.0,"rate":0.010000,"tax":0.05,"taxCalculated":0.05,"nonTaxable":0.0,"exemption":0.0}]}'
+    http_version: 
+  recorded_at: Tue, 26 Jun 2018 22:34:50 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr/SolidusAvataxCertified_Request_GetTax/_generate/with_a_line_item_discount/sends_the_full_item_price_and_an_invoice_discount.yml
+++ b/spec/vcr/SolidusAvataxCertified_Request_GetTax/_generate/with_a_line_item_discount/sends_the_full_item_price_and_an_invoice_discount.yml
@@ -5,13 +5,13 @@ http_interactions:
     uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
     body:
       encoding: UTF-8
-      string: '{"createTransactionModel":{"code":"R123164970","date":"2018-06-26","discount":"5.0","commit":false,"type":"SalesOrder","lines":[{"number":"1-LI","description":"Product
-        #2 - 5976","taxCode":"PC030000","itemCode":"SKU-2","quantity":1,"amount":5.0,"discounted":true,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
+      string: '{"createTransactionModel":{"code":"R940321904","date":"2018-06-28","discount":5.0,"commit":false,"type":"SalesOrder","lines":[{"number":"1-LI","description":"Product
+        #3 - 9182","taxCode":"PC030000","itemCode":"SKU-3","quantity":1,"amount":5.0,"discounted":true,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
         Lombard Street","line2":null,"city":"San Francisco","region":"CA","country":"US","postalCode":"94109"},"shipTo":{"line1":"42
         Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null},{"number":"1-FR","itemCode":"Avalara
         Ground","quantity":1,"amount":5.0,"description":"Shipping Charge","taxCode":"FR000000","discounted":false,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
         Lombard Street","line2":null,"city":"San Francisco","region":"CA","country":"US","postalCode":"94109"},"shipTo":{"line1":"42
-        Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null}],"customerCode":1,"companyCode":"001","customerUsageType":null,"exemptionNo":null,"referenceCode":"R123164970","currencyCode":"USD","businessIdentificationNo":null}}'
+        Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null}],"customerCode":1,"companyCode":"001","customerUsageType":null,"exemptionNo":null,"referenceCode":"R940321904","currencyCode":"USD","businessIdentificationNo":null}}'
     headers:
       X-Avalara-Uid:
       - a0o33000004FH8l
@@ -31,7 +31,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 26 Jun 2018 22:34:50 GMT
+      - Thu, 28 Jun 2018 18:51:10 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -43,19 +43,19 @@ http_interactions:
       Server:
       - Kestrel
       Serverduration:
-      - '00:00:00.0993445'
+      - '00:00:00.2129886'
       Databasecalls:
       - '0'
       Databaseduration:
       - '00:00:00'
       Serviceduration:
-      - '00:00:00.0955463'
+      - '00:00:00.2089171'
       X-Powered-By:
       - ASP.NET
     body:
       encoding: UTF-8
-      string: '{"id":0,"code":"R123164970","companyId":0,"date":"2018-06-26","paymentDate":"2018-06-26","status":"Temporary","type":"SalesOrder","currencyCode":"USD","customerVendorCode":"1","customerCode":"1","reconciled":false,"referenceCode":"R123164970","totalAmount":10.0,"totalExempt":0.0,"totalDiscount":5.0,"totalTax":0.47,"totalTaxable":5.0,"totalTaxCalculated":0.47,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2018-06-26","exchangeRate":1.0,"modifiedDate":"2018-06-26T22:34:49.8040203Z","modifiedUserId":41103,"taxDate":"2018-06-26T00:00:00","lines":[{"id":0,"transactionId":0,"lineNumber":"1-LI","description":"Product
-        #2 - 5976","discountAmount":5.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"SKU-2","lineAmount":0.0,"quantity":1.0,"reportingDate":"2018-06-26","tax":0.0,"taxableAmount":0.0,"taxCalculated":0.0,"taxCode":"PC030000","taxCodeId":8107,"taxDate":"2018-06-26","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+      string: '{"id":0,"code":"R940321904","companyId":0,"date":"2018-06-28","paymentDate":"2018-06-28","status":"Temporary","type":"SalesOrder","currencyCode":"USD","customerVendorCode":"1","customerCode":"1","reconciled":false,"referenceCode":"R940321904","totalAmount":10.0,"totalExempt":0.0,"totalDiscount":5.0,"totalTax":0.47,"totalTaxable":5.0,"totalTaxCalculated":0.47,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2018-06-28","exchangeRate":1.0,"modifiedDate":"2018-06-28T18:51:06.9226386Z","modifiedUserId":41103,"taxDate":"2018-06-28T00:00:00","lines":[{"id":0,"transactionId":0,"lineNumber":"1-LI","description":"Product
+        #3 - 9182","discountAmount":5.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"SKU-3","lineAmount":0.0,"quantity":1.0,"reportingDate":"2018-06-28","tax":0.0,"taxableAmount":0.0,"taxCalculated":0.0,"taxCode":"PC030000","taxCodeId":8107,"taxDate":"2018-06-28","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
         STATE TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"075","jurisName":"SAN
         FRANCISCO","stateAssignedNo":"","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0,"rate":0.002500,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
         COUNTY TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMAR0","jurisName":"LOS
@@ -64,7 +64,7 @@ http_interactions:
         FRANCISCO CO LOCAL TAX SL","stateAssignedNo":"38","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.010000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
         SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"","vatNumberTypeId":0},{"id":0,"transactionId":0,"lineNumber":"1-FR","description":"Shipping
         Charge","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"Avalara
-        Ground","lineAmount":5.0,"quantity":1.0,"reportingDate":"2018-06-26","tax":0.47,"taxableAmount":5.0,"taxCalculated":0.47,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2018-06-26","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.3,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        Ground","lineAmount":5.0,"quantity":1.0,"reportingDate":"2018-06-28","tax":0.47,"taxableAmount":5.0,"taxCalculated":0.47,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2018-06-28","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.3,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
         STATE TAX","taxAuthorityTypeId":45,"taxCalculated":0.3,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"075","jurisName":"SAN
         FRANCISCO","stateAssignedNo":"","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0,"rate":0.002500,"tax":0.01,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
         COUNTY TAX","taxAuthorityTypeId":45,"taxCalculated":0.01,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMAR0","jurisName":"LOS
@@ -82,19 +82,19 @@ http_interactions:
         FRANCISCO CO LOCAL TAX SL","taxAuthorityType":45,"stateAssignedNo":"38","taxType":"Sales","taxName":"CA
         SPECIAL TAX","rateType":"General","taxable":5.0,"rate":0.010000,"tax":0.05,"taxCalculated":0.05,"nonTaxable":0.0,"exemption":0.0}]}'
     http_version: 
-  recorded_at: Tue, 26 Jun 2018 22:34:50 GMT
+  recorded_at: Thu, 28 Jun 2018 18:51:10 GMT
 - request:
     method: post
     uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
     body:
       encoding: UTF-8
-      string: '{"createTransactionModel":{"code":"R123164970","date":"2018-06-26","discount":"5.0","commit":false,"type":"SalesOrder","lines":[{"number":"1-LI","description":"Product
-        #2 - 5976","taxCode":"PC030000","itemCode":"SKU-2","quantity":1,"amount":5.0,"discounted":true,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
+      string: '{"createTransactionModel":{"code":"R940321904","date":"2018-06-28","discount":5.0,"commit":false,"type":"SalesOrder","lines":[{"number":"1-LI","description":"Product
+        #3 - 9182","taxCode":"PC030000","itemCode":"SKU-3","quantity":1,"amount":5.0,"discounted":true,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
         Lombard Street","line2":null,"city":"San Francisco","region":"CA","country":"US","postalCode":"94109"},"shipTo":{"line1":"42
         Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null},{"number":"1-FR","itemCode":"Avalara
         Ground","quantity":1,"amount":5.0,"description":"Shipping Charge","taxCode":"FR000000","discounted":false,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
         Lombard Street","line2":null,"city":"San Francisco","region":"CA","country":"US","postalCode":"94109"},"shipTo":{"line1":"42
-        Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null}],"customerCode":1,"companyCode":"001","customerUsageType":null,"exemptionNo":null,"referenceCode":"R123164970","currencyCode":"USD","businessIdentificationNo":null}}'
+        Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null}],"customerCode":1,"companyCode":"001","customerUsageType":null,"exemptionNo":null,"referenceCode":"R940321904","currencyCode":"USD","businessIdentificationNo":null}}'
     headers:
       X-Avalara-Uid:
       - a0o33000004FH8l
@@ -114,7 +114,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 26 Jun 2018 22:34:50 GMT
+      - Thu, 28 Jun 2018 18:51:10 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -126,19 +126,19 @@ http_interactions:
       Server:
       - Kestrel
       Serverduration:
-      - '00:00:00.1014522'
+      - '00:00:00.0907786'
       Databasecalls:
       - '0'
       Databaseduration:
       - '00:00:00'
       Serviceduration:
-      - '00:00:00.0973509'
+      - '00:00:00.0876153'
       X-Powered-By:
       - ASP.NET
     body:
       encoding: UTF-8
-      string: '{"id":0,"code":"R123164970","companyId":0,"date":"2018-06-26","paymentDate":"2018-06-26","status":"Temporary","type":"SalesOrder","currencyCode":"USD","customerVendorCode":"1","customerCode":"1","reconciled":false,"referenceCode":"R123164970","totalAmount":10.0,"totalExempt":0.0,"totalDiscount":5.0,"totalTax":0.47,"totalTaxable":5.0,"totalTaxCalculated":0.47,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2018-06-26","exchangeRate":1.0,"modifiedDate":"2018-06-26T22:34:50.25904Z","modifiedUserId":41103,"taxDate":"2018-06-26T00:00:00","lines":[{"id":0,"transactionId":0,"lineNumber":"1-LI","description":"Product
-        #2 - 5976","discountAmount":5.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"SKU-2","lineAmount":0.0,"quantity":1.0,"reportingDate":"2018-06-26","tax":0.0,"taxableAmount":0.0,"taxCalculated":0.0,"taxCode":"PC030000","taxCodeId":8107,"taxDate":"2018-06-26","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+      string: '{"id":0,"code":"R940321904","companyId":0,"date":"2018-06-28","paymentDate":"2018-06-28","status":"Temporary","type":"SalesOrder","currencyCode":"USD","customerVendorCode":"1","customerCode":"1","reconciled":false,"referenceCode":"R940321904","totalAmount":10.0,"totalExempt":0.0,"totalDiscount":5.0,"totalTax":0.47,"totalTaxable":5.0,"totalTaxCalculated":0.47,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2018-06-28","exchangeRate":1.0,"modifiedDate":"2018-06-28T18:51:04.8499528Z","modifiedUserId":41103,"taxDate":"2018-06-28T00:00:00","lines":[{"id":0,"transactionId":0,"lineNumber":"1-LI","description":"Product
+        #3 - 9182","discountAmount":5.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"SKU-3","lineAmount":0.0,"quantity":1.0,"reportingDate":"2018-06-28","tax":0.0,"taxableAmount":0.0,"taxCalculated":0.0,"taxCode":"PC030000","taxCodeId":8107,"taxDate":"2018-06-28","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
         STATE TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"075","jurisName":"SAN
         FRANCISCO","stateAssignedNo":"","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0,"rate":0.002500,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
         COUNTY TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMAR0","jurisName":"LOS
@@ -147,7 +147,7 @@ http_interactions:
         FRANCISCO CO LOCAL TAX SL","stateAssignedNo":"38","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.010000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
         SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"","vatNumberTypeId":0},{"id":0,"transactionId":0,"lineNumber":"1-FR","description":"Shipping
         Charge","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"Avalara
-        Ground","lineAmount":5.0,"quantity":1.0,"reportingDate":"2018-06-26","tax":0.47,"taxableAmount":5.0,"taxCalculated":0.47,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2018-06-26","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.3,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        Ground","lineAmount":5.0,"quantity":1.0,"reportingDate":"2018-06-28","tax":0.47,"taxableAmount":5.0,"taxCalculated":0.47,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2018-06-28","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.3,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
         STATE TAX","taxAuthorityTypeId":45,"taxCalculated":0.3,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"075","jurisName":"SAN
         FRANCISCO","stateAssignedNo":"","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0,"rate":0.002500,"tax":0.01,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
         COUNTY TAX","taxAuthorityTypeId":45,"taxCalculated":0.01,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMAR0","jurisName":"LOS
@@ -165,5 +165,5 @@ http_interactions:
         FRANCISCO CO LOCAL TAX SL","taxAuthorityType":45,"stateAssignedNo":"38","taxType":"Sales","taxName":"CA
         SPECIAL TAX","rateType":"General","taxable":5.0,"rate":0.010000,"tax":0.05,"taxCalculated":0.05,"nonTaxable":0.0,"exemption":0.0}]}'
     http_version: 
-  recorded_at: Tue, 26 Jun 2018 22:34:50 GMT
+  recorded_at: Thu, 28 Jun 2018 18:51:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/SolidusAvataxCertified_Request_GetTax/_generate/with_free_shipping/sends_the_discounted_shipment_amount.yml
+++ b/spec/vcr/SolidusAvataxCertified_Request_GetTax/_generate/with_free_shipping/sends_the_discounted_shipment_amount.yml
@@ -1,0 +1,86 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+    body:
+      encoding: UTF-8
+      string: '{"createTransactionModel":{"code":"R111839419","date":"2018-06-28","discount":0.0,"commit":false,"type":"SalesOrder","lines":[{"number":"1-LI","description":"Product
+        #2 - 695","taxCode":"PC030000","itemCode":"SKU-2","quantity":1,"amount":5.0,"discounted":false,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
+        Lombard Street","line2":null,"city":"San Francisco","region":"CA","country":"US","postalCode":"94109"},"shipTo":{"line1":"42
+        Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null},{"number":"1-FR","itemCode":"Avalara
+        Ground","quantity":1,"amount":0.0,"description":"Shipping Charge","taxCode":"FR000000","discounted":false,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1070
+        Lombard Street","line2":null,"city":"San Francisco","region":"CA","country":"US","postalCode":"94109"},"shipTo":{"line1":"42
+        Fake Street","line2":"Southeast","city":"Los Angeles","region":"CA","country":"US","postalCode":"90210"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null}],"customerCode":1,"companyCode":"001","customerUsageType":null,"exemptionNo":null,"referenceCode":"R111839419","currencyCode":"USD","businessIdentificationNo":null}}'
+    headers:
+      X-Avalara-Uid:
+      - a0o33000004FH8l
+      User-Agent:
+      - Faraday v0.15.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic MTEwMDEyNzQwNjo2MEM4RTU4RkYxMDU1MjBD
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 28 Jun 2018 18:51:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Location:
+      - "/api/v2/companies/0/transactions/0"
+      Server:
+      - Kestrel
+      Serverduration:
+      - '00:00:00.0992903'
+      Databasecalls:
+      - '0'
+      Databaseduration:
+      - '00:00:00'
+      Serviceduration:
+      - '00:00:00.0953158'
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: '{"id":0,"code":"R111839419","companyId":0,"date":"2018-06-28","paymentDate":"2018-06-28","status":"Temporary","type":"SalesOrder","currencyCode":"USD","customerVendorCode":"1","customerCode":"1","reconciled":false,"referenceCode":"R111839419","totalAmount":5.0,"totalExempt":0.0,"totalDiscount":0.0,"totalTax":0.47,"totalTaxable":5.0,"totalTaxCalculated":0.47,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2018-06-28","exchangeRate":1.0,"modifiedDate":"2018-06-28T18:51:04.6611166Z","modifiedUserId":41103,"taxDate":"2018-06-28T00:00:00","lines":[{"id":0,"transactionId":0,"lineNumber":"1-LI","description":"Product
+        #2 - 695","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"SKU-2","lineAmount":5.0,"quantity":1.0,"reportingDate":"2018-06-28","tax":0.47,"taxableAmount":5.0,"taxCalculated":0.47,"taxCode":"PC030000","taxCodeId":8107,"taxDate":"2018-06-28","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.3,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        STATE TAX","taxAuthorityTypeId":45,"taxCalculated":0.3,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"075","jurisName":"SAN
+        FRANCISCO","stateAssignedNo":"","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0,"rate":0.002500,"tax":0.01,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        COUNTY TAX","taxAuthorityTypeId":45,"taxCalculated":0.01,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMAR0","jurisName":"LOS
+        ANGELES COUNTY DISTRICT TAX SP","stateAssignedNo":"594","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.022500,"tax":0.11,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.11,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMTV0","jurisName":"SAN
+        FRANCISCO CO LOCAL TAX SL","stateAssignedNo":"38","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.010000,"tax":0.05,"taxableAmount":5.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.05,"rateType":"General","rateTypeCode":"G","isNonPassThru":false}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"","vatNumberTypeId":0},{"id":0,"transactionId":0,"lineNumber":"1-FR","description":"Shipping
+        Charge","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"isItemTaxable":true,"itemCode":"Avalara
+        Ground","lineAmount":0.0,"quantity":1.0,"reportingDate":"2018-06-28","tax":0.0,"taxableAmount":0.0,"taxCalculated":0.0,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2018-06-28","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"06","jurisName":"CALIFORNIA","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0,"rate":0.060000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        STATE TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"075","jurisName":"SAN
+        FRANCISCO","stateAssignedNo":"","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0,"rate":0.002500,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        COUNTY TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMAR0","jurisName":"LOS
+        ANGELES COUNTY DISTRICT TAX SP","stateAssignedNo":"594","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.022500,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false},{"id":0,"transactionLineId":0,"transactionId":0,"country":"US","region":"CA","exemptAmount":0.0,"jurisCode":"EMTV0","jurisName":"SAN
+        FRANCISCO CO LOCAL TAX SL","stateAssignedNo":"38","jurisType":"STJ","jurisdictionType":"Special","nonTaxableAmount":0.0,"rate":0.010000,"tax":0.0,"taxableAmount":0.0,"taxType":"Sales","taxName":"CA
+        SPECIAL TAX","taxAuthorityTypeId":45,"taxCalculated":0.0,"rateType":"General","rateTypeCode":"G","isNonPassThru":false}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"","vatNumberTypeId":0}],"addresses":[{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"42
+        Fake Street","line2":"Southeast","line3":"","city":"Los Angeles","region":"CA","postalCode":"90210","country":"US","taxRegionId":2127184,"latitude":"34.086013","longitude":"-118.404905"},{"id":0,"transactionId":0,"boundaryLevel":"Address","line1":"1070
+        Lombard Street","line2":"","line3":"","city":"San Francisco","region":"CA","postalCode":"94109","country":"US","taxRegionId":2128434,"latitude":"37.802069","longitude":"-122.41912"}],"summary":[{"country":"US","region":"CA","jurisType":"State","jurisCode":"06","jurisName":"CALIFORNIA","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Sales","taxName":"CA
+        STATE TAX","rateType":"General","taxable":5.0,"rate":0.060000,"tax":0.3,"taxCalculated":0.3,"nonTaxable":0.0,"exemption":0.0},{"country":"US","region":"CA","jurisType":"County","jurisCode":"075","jurisName":"SAN
+        FRANCISCO","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Sales","taxName":"CA
+        COUNTY TAX","rateType":"General","taxable":5.0,"rate":0.002500,"tax":0.01,"taxCalculated":0.01,"nonTaxable":0.0,"exemption":0.0},{"country":"US","region":"CA","jurisType":"Special","jurisCode":"EMAR0","jurisName":"LOS
+        ANGELES COUNTY DISTRICT TAX SP","taxAuthorityType":45,"stateAssignedNo":"594","taxType":"Sales","taxName":"CA
+        SPECIAL TAX","rateType":"General","taxable":5.0,"rate":0.022500,"tax":0.11,"taxCalculated":0.11,"nonTaxable":0.0,"exemption":0.0},{"country":"US","region":"CA","jurisType":"Special","jurisCode":"EMTV0","jurisName":"SAN
+        FRANCISCO CO LOCAL TAX SL","taxAuthorityType":45,"stateAssignedNo":"38","taxType":"Sales","taxName":"CA
+        SPECIAL TAX","rateType":"General","taxable":5.0,"rate":0.010000,"tax":0.05,"taxCalculated":0.05,"nonTaxable":0.0,"exemption":0.0}]}'
+    http_version: 
+  recorded_at: Thu, 28 Jun 2018 18:51:08 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Currently we are sending the full price for line items and passing the discount in the invoice total discount (which gets distributed evenly among items marked as `discounted`). For shipments we send the discounted amount, but the discount is still added to the invoice total discount, so they get double counted.

This excludes shipment promotions from the total invoice discount because they have already been accounted for.

There is another potential issue not account for here, which is if there are multiple discounted line items but they are taxed at different tax rates when Avalara distributes the total discount amount, we can end up with incorrect taxes.