### PR TITLE
Don't error on non-calculated adjustments

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -10,9 +10,9 @@ Spree::Order.class_eval do
                                       :if => :address_validation_enabled?
 
   def avalara_tax_enabled?
-    avalara_transaction.present? || all_adjustments.any? {
-      |adj| adj.source&.calculator.kind_of? Spree::Calculator::AvalaraTransaction
-    }
+    avalara_transaction.present? || all_adjustments.any? do |adj|
+      adj.source.try(:calculator).kind_of? Spree::Calculator::AvalaraTransaction
+    end
   end
 
   def cancel_avalara


### PR DESCRIPTION
The safe navigation operator `&.` checks if the object responds to the method and throws an error if it doesn't. Since not all adjustment sources include the Spree::CalculatedAdjustments module, they don't all respond to `.calculator`. One such example is the free shipping promotion action. These adjustments would cause this method to throw an error and blow up order completion because we check this on the payment's transition to complete.