### PR TITLE
Send tax date override for completed orders

### DIFF
--- a/app/models/solidus_avatax_certified/request/base.rb
+++ b/app/models/solidus_avatax_certified/request/base.rb
@@ -25,7 +25,21 @@ module SolidusAvataxCertified
           referenceCode: order.number,
           currencyCode: order.currency,
           businessIdentificationNo: business_id_no
-        }
+        }.merge(tax_date_override)
+      end
+
+      def tax_date_override
+        if order.completed?
+          {
+            taxOverride: {
+              type: 'TaxDate',
+              reason: 'Completed At',
+              taxDate: order.completed_at.strftime('%F')
+            }
+          }
+        else
+          {}
+        end
       end
 
       def address_lines

--- a/spec/models/solidus_avatax_certified/request/get_tax_spec.rb
+++ b/spec/models/solidus_avatax_certified/request/get_tax_spec.rb
@@ -176,5 +176,22 @@ RSpec.describe SolidusAvataxCertified::Request::GetTax, :vcr do
         )
       end
     end
+
+    context "with a completed order" do
+      let(:completed_at) { Time.parse("2018-02-28") }
+      let(:order) { create(:order, state: 'complete', completed_at: completed_at) }
+
+      it "includes a tax date override" do
+        expect(subject).to include(
+          createTransactionModel: hash_including(
+            taxOverride: {
+              type: 'TaxDate',
+              reason: 'Completed At',
+              taxDate: "2018-02-28"
+            }
+          )
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This is already done for the return_tax request, but not for the standard get_tax request.

Since Solidus recalculates taxes on every order update, if the rates change and the order is updated after it completes (ie: when it ships), the taxes will be recalculated at the new rate and the order will either end up in `balance_due` or `credit_owed`.

This change ensures that we always send a tax date override for orders that have a `completed_at` timestamp set.