### PR TITLE
Allow taxes to be calculated on non-persisted line_items and shipments

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -25,7 +25,7 @@ module SolidusAvataxCertified
 
     def item_line(line_item)
       {
-        number: "#{line_item.id}-LI",
+        number: "#{line_item.id || line_item.object_id}-LI",
         description: line_item.name[0..255],
         taxCode: line_item.tax_category.try(:tax_code) || '',
         itemCode: line_item.variant.sku,
@@ -55,7 +55,7 @@ module SolidusAvataxCertified
 
     def shipment_line(shipment)
       {
-        number: "#{shipment.id}-FR",
+        number: "#{shipment.id || shipment.object_id}-FR",
         itemCode: shipment.shipping_method.name,
         quantity: 1,
         amount: shipment.total_before_tax.to_f,

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -91,7 +91,7 @@ module Spree
       return 0 if avalara_response[:totalTax] == 0.0
 
       avalara_response['lines'].each do |line|
-        if line['lineNumber'] == "#{item.id}-#{item.avatax_line_code}"
+        if line['lineNumber'] == "#{item.id || item.object_id}-#{item.avatax_line_code}"
           return line['taxCalculated']
         end
       end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -24,7 +24,9 @@ Spree::Order.class_eval do
     logger.info "Start avalara_capture for order #{number}"
 
     create_avalara_transaction if avalara_transaction.nil?
-    line_items.reload
+    if persisted?
+      line_items.reload
+    end
 
     avalara_transaction.commit_avatax('SalesOrder')
   end
@@ -33,7 +35,10 @@ Spree::Order.class_eval do
     logger.info "Start avalara_capture_finalize for order #{number}"
 
     create_avalara_transaction if avalara_transaction.nil?
-    line_items.reload
+
+    if persisted?
+      line_items.reload
+    end
 
     avalara_transaction.commit_avatax_final('SalesInvoice')
   end

--- a/spec/models/solidus_avatax_certified/line_spec.rb
+++ b/spec/models/solidus_avatax_certified/line_spec.rb
@@ -1,105 +1,107 @@
 require 'spec_helper'
 
 describe SolidusAvataxCertified::Line, :vcr do
-  let(:order) { create(:avalara_order, line_items_count: 2) }
-  let(:sales_lines) { SolidusAvataxCertified::Line.new(order, 'SalesOrder') }
+  context 'with a persisted order' do
+    let(:order) { create(:avalara_order, line_items_count: 2) }
+    let(:sales_lines) { SolidusAvataxCertified::Line.new(order, 'SalesOrder') }
 
-  before do
-    VCR.use_cassette("order_capture", allow_playback_repeats: true) do
-      order
-    end
-  end
-
-  describe '#initialize' do
-    it 'should have order' do
-      expect(sales_lines.order).to eq(order)
-    end
-    it 'should have lines be an array' do
-      expect(sales_lines.lines).to be_kind_of(Array)
-    end
-    it 'lines should be a length of 3' do
-      expect(sales_lines.lines.length).to eq(3)
-    end
-  end
-
-  context 'sales order' do
-    describe '#build_lines' do
-      it 'receives method item_lines_array' do
-        expect(sales_lines).to receive(:item_lines_array)
-        sales_lines.build_lines
-      end
-      it 'receives method shipment_lines_array' do
-        expect(sales_lines).to receive(:shipment_lines_array)
-        sales_lines.build_lines
+    before do
+      VCR.use_cassette("order_capture", allow_playback_repeats: true) do
+        order
       end
     end
 
-    describe '#item_lines_array' do
-      it 'returns an Array' do
-        expect(sales_lines.item_lines_array).to be_kind_of(Array)
+    describe '#initialize' do
+      it 'should have order' do
+        expect(sales_lines.order).to eq(order)
+      end
+      it 'should have lines be an array' do
+        expect(sales_lines.lines).to be_kind_of(Array)
+      end
+      it 'lines should be a length of 3' do
+        expect(sales_lines.lines.length).to eq(3)
       end
     end
 
-    describe '#shipment_lines_array' do
-      it 'returns an Array' do
-        expect(sales_lines.shipment_lines_array).to be_kind_of(Array)
+    context 'sales order' do
+      describe '#build_lines' do
+        it 'receives method item_lines_array' do
+          expect(sales_lines).to receive(:item_lines_array)
+          sales_lines.build_lines
+        end
+        it 'receives method shipment_lines_array' do
+          expect(sales_lines).to receive(:shipment_lines_array)
+          sales_lines.build_lines
+        end
       end
-      it 'should have a length of 1' do
-        expect(sales_lines.shipment_lines_array.length).to eq(1)
+
+      describe '#item_lines_array' do
+        it 'returns an Array' do
+          expect(sales_lines.item_lines_array).to be_kind_of(Array)
+        end
+      end
+
+      describe '#shipment_lines_array' do
+        it 'returns an Array' do
+          expect(sales_lines.shipment_lines_array).to be_kind_of(Array)
+        end
+        it 'should have a length of 1' do
+          expect(sales_lines.shipment_lines_array.length).to eq(1)
+        end
+      end
+
+      describe '#item_line' do
+        it 'returns a Hash with correct keys' do
+          expect(sales_lines.item_line(order.line_items.first)).to be_kind_of(Hash)
+          expect(sales_lines.item_line(order.line_items.first)[:number]).to be_present
+        end
+      end
+      describe '#shipment_line' do
+        it 'returns a Hash with correct keys' do
+          expect(sales_lines.shipment_line(order.shipments.first)).to be_kind_of(Hash)
+          expect(sales_lines.shipment_line(order.shipments.first)[:number]).to be_present
+        end
       end
     end
 
-    describe '#item_line' do
-      it 'returns a Hash with correct keys' do
-        expect(sales_lines.item_line(order.line_items.first)).to be_kind_of(Hash)
-        expect(sales_lines.item_line(order.line_items.first)[:number]).to be_present
-      end
-    end
-    describe '#shipment_line' do
-      it 'returns a Hash with correct keys' do
-        expect(sales_lines.shipment_line(order.shipments.first)).to be_kind_of(Hash)
-        expect(sales_lines.shipment_line(order.shipments.first)[:number]).to be_present
-      end
-    end
-  end
+    context 'return invoice' do
+      let(:authorization) { generate(:refund_transaction_id) }
+      let(:payment_amount) { 10*2 }
+      let(:payment_method) { build(:credit_card_payment_method) }
+      let(:payment) { build(:payment, amount: payment_amount, payment_method: payment_method, order: order) }
+      let(:refund_reason) { build(:refund_reason) }
+      let(:gateway_response) {
+        ActiveMerchant::Billing::Response.new(
+          gateway_response_success,
+          gateway_response_message,
+          gateway_response_params,
+          gateway_response_options
+        )
+      }
+      let(:gateway_response_success) { true }
+      let(:gateway_response_message) { '' }
+      let(:gateway_response_params) { {} }
+      let(:gateway_response_options) { {} }
 
-  context 'return invoice' do
-    let(:authorization) { generate(:refund_transaction_id) }
-    let(:payment_amount) { 10*2 }
-    let(:payment_method) { build(:credit_card_payment_method) }
-    let(:payment) { build(:payment, amount: payment_amount, payment_method: payment_method, order: order) }
-    let(:refund_reason) { build(:refund_reason) }
-    let(:gateway_response) {
-      ActiveMerchant::Billing::Response.new(
-        gateway_response_success,
-        gateway_response_message,
-        gateway_response_params,
-        gateway_response_options
-      )
-    }
-    let(:gateway_response_success) { true }
-    let(:gateway_response_message) { '' }
-    let(:gateway_response_params) { {} }
-    let(:gateway_response_options) { {} }
+      let(:refund) {Spree::Refund.new(payment: payment, amount: BigDecimal.new(10), reason: refund_reason, transaction_id: nil)}
+      let(:shipped_order) { build(:shipped_order) }
+      let(:return_lines) { SolidusAvataxCertified::Line.new(shipped_order, 'ReturnOrder', refund) }
 
-    let(:refund) {Spree::Refund.new(payment: payment, amount: BigDecimal.new(10), reason: refund_reason, transaction_id: nil)}
-    let(:shipped_order) { build(:shipped_order) }
-    let(:return_lines) { SolidusAvataxCertified::Line.new(shipped_order, 'ReturnOrder', refund) }
-
-    describe 'build_lines' do
-      it 'receives method refund_lines' do
-        expect(return_lines).to receive(:refund_lines)
-        return_lines.build_lines
+      describe 'build_lines' do
+        it 'receives method refund_lines' do
+          expect(return_lines).to receive(:refund_lines)
+          return_lines.build_lines
+        end
       end
-    end
-    describe '#refund_line' do
-      it 'returns an Hash' do
-        expect(return_lines.refund_line).to be_kind_of(Hash)
+      describe '#refund_line' do
+        it 'returns an Hash' do
+          expect(return_lines.refund_line).to be_kind_of(Hash)
+        end
       end
-    end
-    describe '#refund_line' do
-      it 'returns an Array' do
-        expect(return_lines.refund_lines).to be_kind_of(Array)
+      describe '#refund_line' do
+        it 'returns an Array' do
+          expect(return_lines.refund_lines).to be_kind_of(Array)
+        end
       end
     end
   end


### PR DESCRIPTION
In order to use `solidus_avatax_certified` on non-persisted line_items and shipments, a few small changes are needed.

- The call to `line_items.reload` has been wrapped in a guard to ensure that the order is persisted. If it is not, calling reload on the line_items will render them inaccessible.

- Places relying on `.id` of possible non-persisted objects have been updated to use `.object_id` as a fallback. It's crucial that these `number` assignments be unique for the order, and if the `.id` resolves to `nil`, multiple line_items or shipments will return errors from Avatax. In these cases, it makes sense to use another unique identifier. Since we are only working with non-persisted objects, ensuring the [cache](https://github.com/cbrunsdon/solidus_avatax_certified/blob/master/app/models/spree/calculator/avalara_transaction.rb#L64-L99) is valid across requests is unnecessary, and if the object becomes persisted, the cache key will be changed.