### PR TITLE
In memory improvements

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -25,7 +25,7 @@ module SolidusAvataxCertified
 
     def item_line(line_item)
       {
-        number: "#{line_item.id || line_item.object_id}-LI",
+        number: "#{line_item.avatax_digest}-LI",
         description: line_item.name[0..255],
         taxCode: line_item.tax_category.try(:tax_code) || '',
         itemCode: line_item.variant.sku,

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -91,7 +91,7 @@ module Spree
       return 0 if avalara_response[:totalTax] == 0.0
 
       avalara_response['lines'].each do |line|
-        if line['lineNumber'] == "#{item.id || item.object_id}-#{item.avatax_line_code}"
+        if line['lineNumber'] == "#{item.avatax_digest}-#{item.avatax_line_code}"
           return line['taxCalculated']
         end
       end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -22,4 +22,8 @@ Spree::LineItem.class_eval do
   def avatax_line_code
     'LI'
   end
+
+  def avatax_digest
+    id || variant.sku
+  end
 end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -23,9 +23,11 @@ Spree::Order.class_eval do
   def avalara_capture
     logger.info "Start avalara_capture for order #{number}"
 
-    create_avalara_transaction if avalara_transaction.nil?
     if persisted?
+      create_avalara_transaction if avalara_transaction.nil?
       line_items.reload
+    elsif avalara_transaction.nil?
+      build_avalara_transaction
     end
 
     avalara_transaction.commit_avatax('SalesOrder')
@@ -34,10 +36,11 @@ Spree::Order.class_eval do
   def avalara_capture_finalize
     logger.info "Start avalara_capture_finalize for order #{number}"
 
-    create_avalara_transaction if avalara_transaction.nil?
-
     if persisted?
+      create_avalara_transaction if avalara_transaction.nil?
       line_items.reload
+    elsif avalara_transaction.nil?
+      build_avalara_transaction
     end
 
     avalara_transaction.commit_avatax_final('SalesInvoice')

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -13,6 +13,10 @@ Spree::Shipment.class_eval do
     'FR'
   end
 
+  def avatax_digest
+    id || object_id
+  end
+
   def shipping_method_tax_code
     tax_code = shipping_method.tax_category.try(:tax_code)
     if tax_code.nil?

--- a/spec/models/solidus_avatax_certified/line_spec.rb
+++ b/spec/models/solidus_avatax_certified/line_spec.rb
@@ -127,7 +127,7 @@ describe SolidusAvataxCertified::Line, :vcr do
     it 'uses the line_item object_id in the line_item number' do
       expect(sales_lines.item_line(order.line_items.first)).to be_kind_of(Hash)
       expect(sales_lines.item_line(order.line_items.first)[:number]).to be_present
-      expect(sales_lines.item_line(order.line_items.first)[:number]).to include line_item.object_id.to_s
+      expect(sales_lines.item_line(order.line_items.first)[:number]).to include variant.sku
     end
 
     it 'uses the shipment object_id in the shipment number' do


### PR DESCRIPTION
This makes two improvements to ensure that Avatax calculations can be made on a non-persisted order:

1. Use the variant SKU for a line item if the line item is not persisted. Previously we used object_id, however that would not work with VCR requests as the next time the test was run it would have a different object id. This has the caveat that an order cannot have multiple line items with the same SKU, however, we're willing to accept that limitation.

2. Only create an avalara transaction if the order is persisted, otherwise we will build one to use in memory.