### PR TITLE
Conditionally decorate checkout controller

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -1,27 +1,29 @@
-Spree::CheckoutController.class_eval do
-  def validate_address
-    mytax = TaxSvc.new
-    address = permitted_address_validation_attrs
+if SolidusSupport.frontend_available?
+  Spree::CheckoutController.class_eval do
+    def validate_address
+      mytax = TaxSvc.new
+      address = permitted_address_validation_attrs
 
-    address['country'] = Spree::Country.find_by(id: address['country']).try(:iso)
-    address['region'] = Spree::State.find_by(id: address['region']).try(:abbr)
+      address['country'] = Spree::Country.find_by(id: address['country']).try(:iso)
+      address['region'] = Spree::State.find_by(id: address['region']).try(:abbr)
 
-    response = mytax.validate_address(address)
-    result = response.result
+      response = mytax.validate_address(address)
+      result = response.result
 
-    if response.failed?
-      result.merge!({ 'responseCode': 'error', 'errorMessages': response.summary_messages })
+      if response.failed?
+        result.merge!({ 'responseCode': 'error', 'errorMessages': response.summary_messages })
+      end
+
+      respond_to do |format|
+        format.json { render json: result }
+      end
     end
 
-    respond_to do |format|
-      format.json { render json: result }
+
+    private
+
+    def permitted_address_validation_attrs
+      params['address'].permit(:line1, :line2, :city, :postalCode, :country, :region).to_h
     end
-  end
-
-
-  private
-
-  def permitted_address_validation_attrs
-    params['address'].permit(:line1, :line2, :city, :postalCode, :country, :region).to_h
   end
 end


### PR DESCRIPTION
This will only decorate the checkout controller if the frontend is
available. This will allow the gem to work in the absence of
solidus_frontend.