### PR TITLE
Don't compute tax using expired tax rates

### DIFF
--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -9,6 +9,7 @@ module Spree
     end
 
     def compute_shipment_or_line_item(item)
+      return 0 unless rate.active?
       order = item.order
 
       if can_calculate_tax?(order)

--- a/spec/factories/avalara_order_factory.rb
+++ b/spec/factories/avalara_order_factory.rb
@@ -22,7 +22,7 @@ FactoryGirl.define do
         create(:country)
       end
       if Spree::Zone.find_by(name: 'GlobalZone').nil?
-        create(:global_zone, default_tax: true)
+        create(:global_zone)
       end
       if Spree::TaxCategory.first.nil?
         create(:clothing_tax_rate, tax_categories: [create(:tax_category)], included_in_price: evaluator.tax_included)

--- a/spec/models/spree/calculator/avalara_transaction_spec.rb
+++ b/spec/models/spree/calculator/avalara_transaction_spec.rb
@@ -27,6 +27,14 @@ describe Spree::Calculator::AvalaraTransaction, :vcr do
       end
     end
     context 'when computing a line item' do
+      context "when the tax rate is expired" do
+        before { calculator.calculable.update!(expires_at: 1.day.ago) }
+
+        it "returns 0 for the tax amount" do
+          expect(calculator.compute(line_item)).to be_zero
+        end
+      end
+
       context 'when tax is included in price' do
         let(:included_in_price) { true }
         it 'should be equal to the item pre-tax total * rate' do


### PR DESCRIPTION
This calculator inherits from `Spree::Calculator::DefaultTax`, which always returns 0 when trying to compute an item or order using an expired tax rate:
https://github.com/solidusio/solidus/blob/master/core/app/models/spree/calculator/default_tax.rb#L12-L28

However, this gem overrides the `compute_` methods with `compute_shipment_or_line_item`, which removes that behaviour:
https://github.com/cbrunsdon/solidus_avatax_certified/blob/smart-order-avatax-check/app/models/spree/calculator/avalara_transaction.rb#L11-L20

I don't believe there is a valid reason to change this, so I'm adding it to the override here.