### PR TITLE
Improve cache keys for in-memory orders

### DIFF
--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -12,4 +12,14 @@ Spree::Address.class_eval do
   def self.validation_enabled_countries
     Spree::Avatax::Config.address_validation_enabled_countries
   end
+
+  def avatax_cache_key
+    key = ['Spree::Address']
+    key << self.id
+    key << self.zipcode
+    key << self.city
+    key << self.state&.abbr
+    key << self.country.iso
+    key.join('-')
+  end
 end

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -64,7 +64,7 @@ module Spree
 
     def long_cache_key(order)
       key = order.avatax_cache_key
-      key << order.tax_address.try(:cache_key).to_s
+      key << order.tax_address.try(:avatax_cache_key).to_s
       order.line_items.each do |line_item|
         key << line_item.avatax_cache_key
       end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -12,7 +12,7 @@ Spree::LineItem.class_eval do
 
   def avatax_cache_key
     key = ['Spree::LineItem']
-    key << self.id
+    key << self.avatax_digest
     key << self.quantity
     key << self.price
     key << self.promo_total

--- a/spec/models/spree/address_decorator_spec.rb
+++ b/spec/models/spree/address_decorator_spec.rb
@@ -41,4 +41,26 @@ describe Spree::Address, type: :model do
       expect(Spree::Address.validation_enabled_countries).to include('United States')
     end
   end
+
+  describe '#avatax_cache_key' do
+    subject { address.avatax_cache_key }
+
+    context 'with a persisted record' do
+      let(:address) { create(:address, zipcode: 10005) }
+
+      it 'builds a cache key' do
+        expect(subject).
+          to eq("Spree::Address-#{address.id}-10005-Herndon-AL-US")
+      end
+    end
+
+    context 'with a non-persisted record' do
+      let(:address) { build(:address, zipcode: 10005) }
+
+      it 'builds a cache key' do
+        expect(subject).
+          to eq("Spree::Address--10005-Herndon-AL-US")
+      end
+    end
+  end
 end

--- a/spec/models/spree/line_item_decorator_spec.rb
+++ b/spec/models/spree/line_item_decorator_spec.rb
@@ -16,12 +16,26 @@ describe Spree::LineItem, type: :model do
   end
 
   describe '#avatax_cache_key' do
-    it 'should respond with a cache key' do
-      line_item = Spree::LineItem.new(price: 10, id: 1, quantity: 1)
+    context 'with a persisted record' do
+      let(:line_item) do
+        create(:line_item, price: 10, quantity: 1)
+      end
 
-      expected_response = 'Spree::LineItem-1-1-10.0-0.0'
+      it 'should respond with a cache key' do
+        expect(line_item.avatax_cache_key).
+          to eq("Spree::LineItem-#{line_item.id}-1-10.0-0.0")
+      end
+    end
 
-      expect(line_item.avatax_cache_key).to eq(expected_response)
+    context 'with a non-persisted record' do
+      let(:line_item) do
+        build(:line_item, price: 10, quantity: 1)
+      end
+
+      it 'should respond with a cache key' do
+        expect(line_item.avatax_cache_key).
+          to eq("Spree::LineItem-#{line_item.variant.sku}-1-10.0-0.0")
+      end
     end
   end
 


### PR DESCRIPTION
This change adds an `avatax_cache_key` for `Spree::Address` records in favour of using the default Rails `cache_key` which does not produce a unique key for records which have not been persisted. This results in incorrect cache hits for orders containing the same number of items, but with different `tax_address`.

In addition this change improves the `Spree::LineItem#avatax_cache_key` to use the `Spree::Variant#sku` instead of the `id` for records which have not been persisted. This will further ensure we don't have incorrect cache hits in the rare case where two orders with the same address have the same quantity and price of items, which may be for different SKU's and potentially different tax categories.